### PR TITLE
Improve CI DB startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,18 @@ jobs:
           set -e
           wait_for_port() {
             local port="$1"
-            for i in {1..30}; do
+            for i in {1..40}; do
               if nc -z localhost "$port"; then
+                return 0
+              fi
+              sleep 3
+            done
+            return 1
+          }
+          wait_for_mysql() {
+            local project="$1"
+            for i in {1..40}; do
+              if docker compose -p "$project" exec -T db mysqladmin ping -uoperaton -poperaton --silent; then
                 return 0
               fi
               sleep 3
@@ -39,9 +49,12 @@ jobs:
                 sqlserver) port=1433 ;;
                 *) port=0 ;;
               esac
-              if [ "$port" -ne 0 ]; then
-                wait_for_port "$port"
-              fi
+                if [ "$port" -ne 0 ]; then
+                  wait_for_port "$port"
+                  if [ "$db" = "mysql" ] || [ "$db" = "mariadb" ]; then
+                    wait_for_mysql "$project"
+                  fi
+                fi
             fi
             mvn -B -f "$pom" test
             if [ -f "$dir/docker-compose.yml" ]; then


### PR DESCRIPTION
## Summary
- add wait_for_mysql helper to GitHub Actions
- increase port wait retries and call wait_for_mysql for MySQL/MariaDB modules

## Testing
- `mvn -f 1.0.0-beta-4/spring-boot/h2/pom.xml -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cddda9090832db98bccdbbcffa3b6