### PR TITLE
Fix MariaDB startup check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           wait_for_mysql() {
             local project="$1"
             for i in {1..120}; do
-              if docker compose -p "$project" exec -T db mysqladmin ping -uoperaton -poperaton --silent; then
+              if docker compose -p "$project" exec -T db sh -c 'command -v mysqladmin >/dev/null 2>&1 && mysqladmin ping -uoperaton -poperaton --silent || mariadb-admin ping -uoperaton -poperaton --silent'; then
                 return 0
               fi
               sleep 3


### PR DESCRIPTION
## Summary
- fix `wait_for_mysql` to work with MariaDB by falling back to `mariadb-admin`

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d050d3074832d8112e85d893db4e9