### PR TITLE
Fix MariaDB batching error

### DIFF
--- a/1.0.0-beta-4/quarkus/mariadb/src/test/resources/operaton.cfg.xml
+++ b/1.0.0-beta-4/quarkus/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,7 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>

--- a/1.0.0-beta-4/spring-boot/mariadb/src/test/resources/operaton.cfg.xml
+++ b/1.0.0-beta-4/spring-boot/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,7 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>

--- a/1.0.0-beta-4/tomcat/mariadb/src/test/resources/operaton.cfg.xml
+++ b/1.0.0-beta-4/tomcat/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,7 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>

--- a/1.0.0-beta-4/weblogic/mariadb/src/test/resources/operaton.cfg.xml
+++ b/1.0.0-beta-4/weblogic/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,7 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>

--- a/1.0.0-beta-4/websphere/mariadb/src/test/resources/operaton.cfg.xml
+++ b/1.0.0-beta-4/websphere/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,7 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>

--- a/1.0.0-beta-4/wildfly/mariadb/src/test/resources/operaton.cfg.xml
+++ b/1.0.0-beta-4/wildfly/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,7 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>

--- a/template/common-spring/mariadb/src/test/resources/operaton.cfg.xml
+++ b/template/common-spring/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,8 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <!-- disable batch JDBC statements as MariaDB driver does not return affected row count -->
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>

--- a/template/common/mariadb/src/test/resources/operaton.cfg.xml
+++ b/template/common/mariadb/src/test/resources/operaton.cfg.xml
@@ -13,6 +13,8 @@
     <property name="jdbcDriver" value="org.mariadb.jdbc.Driver" />
     <property name="databaseSchemaUpdate" value="true" />
     <property name="skipIsolationLevelCheck" value="true" />
+    <!-- disable batch JDBC statements as MariaDB driver does not return affected row count -->
+    <property name="jdbcBatchProcessing" value="false" />
   </bean>
 
 </beans>


### PR DESCRIPTION
## Summary
- disable batch JDBC statements for MariaDB examples

## Testing
- `docker compose up -d` *(fails: command not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d16aa4518832da438f730e77f507f