### PR TITLE
Improve Oracle DB readiness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,13 @@ jobs:
           }
           wait_for_oracle() {
             local project="$1"
+            local cid
+            cid=$(docker compose -p "$project" ps -q db)
             for i in {1..120}; do
-              if docker compose -p "$project" exec -T db bash -c "echo 'select 1 from dual;' | sqlplus -S operaton/operaton@localhost:1521/XEPDB1 >/dev/null 2>&1"; then
+              if [ "$(docker inspect -f '{{.State.Health.Status}}' "$cid" 2>/dev/null)" = "healthy" ]; then
+                return 0
+              fi
+              if docker compose -p "$project" exec -T db bash -c "echo 'set heading off feedback off; select 1 from dual; exit;' | sqlplus -L -S operaton/operaton@localhost:1521/XEPDB1" | grep -q '^1$'; then
                 return 0
               fi
               sleep 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,16 @@ jobs:
             done
             return 1
           }
+          wait_for_oracle() {
+            local project="$1"
+            for i in {1..120}; do
+              if docker compose -p "$project" exec -T db bash -c "echo 'select 1 from dual;' | sqlplus -S operaton/operaton@localhost:1521/XEPDB1 >/dev/null 2>&1"; then
+                return 0
+              fi
+              sleep 10
+            done
+            return 1
+          }
           for pom in $(find . -path './template' -prune -o -name pom.xml -print); do
             dir=$(dirname "$pom")
             project=$(echo "$dir" | sed 's#^\./##' | tr '/:.' '_')
@@ -74,18 +84,24 @@ jobs:
                     docker compose -p "$project" -f "$dir/docker-compose.yml" logs
                     exit 1
                   fi
-                  case "$db" in
-                    mysql|mariadb)
-                      if ! wait_for_mysql "$project"; then
-                        docker compose -p "$project" -f "$dir/docker-compose.yml" logs
-                        exit 1
-                      fi
-                      ;;
-                    db2)
-                      if ! wait_for_db2 "$project"; then
-                        docker compose -p "$project" -f "$dir/docker-compose.yml" logs
-                        exit 1
-                      fi
+                    case "$db" in
+                      mysql|mariadb)
+                        if ! wait_for_mysql "$project"; then
+                          docker compose -p "$project" -f "$dir/docker-compose.yml" logs
+                          exit 1
+                        fi
+                        ;;
+                      oracle)
+                        if ! wait_for_oracle "$project"; then
+                          docker compose -p "$project" -f "$dir/docker-compose.yml" logs
+                          exit 1
+                        fi
+                        ;;
+                      db2)
+                        if ! wait_for_db2 "$project"; then
+                          docker compose -p "$project" -f "$dir/docker-compose.yml" logs
+                          exit 1
+                        fi
                       ;;
                     sqlserver)
                       if ! wait_for_mssql "$project"; then


### PR DESCRIPTION
## Summary
- wait until Oracle DB responds before running tests

## Testing
- `mvn clean test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1af399ec832d8234051bcb301abd