### PR TITLE
Add database filter for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Build examples
+        env:
+          ENABLED_DBS: mysql
         run: |
           set -e
+          ENABLED_DBS="${ENABLED_DBS:-all}"
           wait_for_port() {
             local port="$1"
             for i in {1..120}; do
@@ -74,6 +77,10 @@ jobs:
             dir=$(dirname "$pom")
             project=$(echo "$dir" | sed 's#^\./##' | tr '/:.' '_')
             db=$(basename "$dir")
+            if [ "$ENABLED_DBS" != "all" ] && [[ ! " $ENABLED_DBS " =~ " $db " ]]; then
+              echo "Skipping $dir because $db tests are disabled"
+              continue
+            fi
             if [ -f "$dir/docker-compose.yml" ]; then
               docker compose -p "$project" -f "$dir/docker-compose.yml" up -d
               case "$db" in

--- a/README.md
+++ b/README.md
@@ -85,5 +85,8 @@ start and stop the containers automatically.
 ## Continuous Integration
 
 A basic GitHub Actions workflow is included at `.github/workflows/ci.yml`.
-It builds every example module on pushes and pull requests. Ensure that the
-repository has GitHub Actions enabled.
+It builds every example module on pushes and pull requests. Set the
+`ENABLED_DBS` environment variable to a space separated list of databases to
+test (e.g. `mysql postgres`). The workflow defaults to all databases when the
+variable is unset.
+Ensure that the repository has GitHub Actions enabled.


### PR DESCRIPTION
## Summary
- allow skipping examples based on `ENABLED_DBS`
- enable only MySQL tests for now
- document the new environment variable

## Testing
- `mvn clean test` *(fails: no root pom)*

------
https://chatgpt.com/codex/tasks/task_e_686257eff418832da94ce79d035ac71d